### PR TITLE
Fix model reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ from rerankers import Reranker
 ranker = Reranker('cross-encoder')
 
 # Specific cross-encoder
-ranker = Reranker('mixedbread-ai/mxbai-rerank-xlarge-v1', model_type='cross-encoder')
+ranker = Reranker('mixedbread-ai/mxbai-rerank-large-v1', model_type='cross-encoder')
 
 # FlashRank default. You can specify a 'lang' parameter to load a multilingual version!
 ranker = Reranker('flashrank')


### PR DESCRIPTION
`xlarge` version seems to be no longer available. See [here](https://huggingface.co/collections/mixedbread-ai/reranking-series-6605a44260cba6d2eec7d4de).