### PR TITLE
feat: add inputs template for T5 rankers

### DIFF
--- a/rerankers/models/t5ranker.py
+++ b/rerankers/models/t5ranker.py
@@ -83,6 +83,7 @@ class T5Ranker(BaseRanker):
         token_false: str = "auto",
         token_true: str = "auto",
         return_logits: bool = False,
+        inputs_template: str = "Query: {query} Document: {text} Relevant:"
     ):
         """
         Implementation of the key functions from https://github.com/unicamp-dl/InRanker/blob/main/inranker/rankers.py
@@ -129,6 +130,8 @@ class T5Ranker(BaseRanker):
             )
         else:
             vprint("Returning normalised scores...", self.verbose)
+        self.inputs_template = inputs_template
+        vprint(f"Inputs template set to {inputs_template}", self.verbose)
 
     def rank(
         self,
@@ -188,7 +191,8 @@ class T5Ranker(BaseRanker):
             total=ceil(len(docs) / batch_size),
         ):
             queries_documents = [
-                f"Query: {query} Document: {text} Relevant:" for text in batch
+                self.inputs_template.format(query=query, text=text)
+                for text in batch
             ]
             tokenized = self.tokenizer(
                 queries_documents,

--- a/rerankers/models/t5ranker.py
+++ b/rerankers/models/t5ranker.py
@@ -57,6 +57,7 @@ def _get_output_tokens(model_name_or_path, token_false: str, token_true: str):
         if model_name_or_path in PREDICTION_TOKENS:
             token_false = PREDICTION_TOKENS[model_name_or_path][0]
         else:
+            token_false = PREDICTION_TOKENS["default"][0]
             print(
                 f"WARNING: Model {model_name_or_path} does not have known True/False tokens. Defaulting token_false to `{token_false}`."
             )

--- a/rerankers/models/t5ranker.py
+++ b/rerankers/models/t5ranker.py
@@ -50,6 +50,10 @@ PREDICTION_TOKENS = {
     "unicamp-dl/ptt5-base-en-pt-msmarco-10k-v1": ["▁não", "▁sim"],
     "unicamp-dl/mt5-3B-mmarco-en-pt": ["▁", "▁true"],
     "unicamp-dl/mt5-13b-mmarco-100k": ["▁", "▁true"],
+    "unicamp-dl/monoptt5-small": ["▁Não", "▁Sim"],
+    "unicamp-dl/monoptt5-base": ["▁Não", "▁Sim"],
+    "unicamp-dl/monoptt5-large": ["▁Não", "▁Sim"],
+    "unicamp-dl/monoptt5-3b": ["▁Não", "▁Sim"],
 }
 
 


### PR DESCRIPTION
## Motivation

Hi, first of all, thanks for your work on this library.

I'm submitting this PR because I will soon publish new MonoT5 rerankers for the Portuguese language, and the ease of use of this library would be very beneficial for users. I trained my models using the translated template `"Pergunta: {query} Documento: {text} Relevante:"`, which requires a small modification to the original code.

I tried to include minimal modifications for my specific case, but let me know if this is out of scope for the library or too specific for my case.

## Changes

1. **Template Specification for T5 Rankers:** Adds the ability to specify the template used for T5 rankers. If no template is specified, it defaults to `"Query: {query} Document: {text} Relevant:"`. (feature)
2. **Default Value for `false_token`:** Sets a default value for `false_token` if the model is not present in `PREDICTION_TOKENS` (fix).

PS.: this PR fixes #17 

