### PR TITLE
Missing f in f-string 

### DIFF
--- a/rerankers/models/colbert_ranker.py
+++ b/rerankers/models/colbert_ranker.py
@@ -94,7 +94,7 @@ class ColBERTModel(BertPreTrainedModel):
             linear_dim = 96
         else:
             linear_dim = 128
-        print("Linear Dim set to: {linear_dim} for downcasting")
+        print(f"Linear Dim set to: {linear_dim} for downcasting")
         self.linear = nn.Linear(config.hidden_size, linear_dim, bias=False)
         self.init_weights()
 


### PR DESCRIPTION
The current output while loading a colbert model looks like this:

```
Loading ColBERTRanker model answerdotai/answerai-colbert-small-v1
No device set
Using device cuda
No dtype set
Using dtype torch.float16
Loading model answerdotai/answerai-colbert-small-v1, this might take a while...
Linear Dim set to: {linear_dim} for downcasting
```

This PR adds a single "f" to the print statement so that {linear_dim} gets displayed appropriately