### PR TITLE
Suppress message with verbose flag

### DIFF
--- a/rerankers/models/colbert_ranker.py
+++ b/rerankers/models/colbert_ranker.py
@@ -94,7 +94,7 @@ class ColBERTModel(BertPreTrainedModel):
             linear_dim = 96
         else:
             linear_dim = 128
-        print(f"Linear Dim set to: {linear_dim} for downcasting")
+        vprint(f"Linear Dim set to: {linear_dim} for downcasting")
         self.linear = nn.Linear(config.hidden_size, linear_dim, bias=False)
         self.init_weights()
 


### PR DESCRIPTION
I'm trying to suppress all stdout using `verbose=0` and noticed that not everything was going away.  I think this `print` should be a `vprint`.  Is it the intention for every `print` to be a `vprint`?  If so I can do those too.