### PR TITLE
Fix: Remove unexpected argument from APIRankers

### DIFF
--- a/rerankers/models/api_rankers.py
+++ b/rerankers/models/api_rankers.py
@@ -91,7 +91,6 @@ class APIRanker(BaseRanker):
             ranked_docs.append(
                 Result(
                     document=docs[r["index"]],
-                    text=self._get_document_text(r),
                     score=self._get_score(r),
                     rank=i + 1,
                 )


### PR DESCRIPTION
With latest change (https://github.com/AnswerDotAI/rerankers/commit/ce422c37352e15357e070508a729eb94d07a7e8b) of moving from Pydantic to a constructor based class, unexpected parameter present in APIRankers makes the initialisation fail.
Removing the unexpected variable `text` from being passed