### PR TITLE
Fix: Add missing verbose argument to vprint in ColBERTModel

### DIFF
--- a/rerankers/models/colbert_ranker.py
+++ b/rerankers/models/colbert_ranker.py
@@ -85,16 +85,16 @@ def _colbert_score(q_reps, p_reps, q_mask: torch.Tensor, p_mask: torch.Tensor):
 
 
 class ColBERTModel(BertPreTrainedModel):
-    def __init__(self, config):
+    def __init__(self, config, verbose: int):
         super().__init__(config)
         self.bert = BertModel(config)
-
+        self.verbose = verbose
         # TODO: Load from artifact.metadata
         if "small" in config._name_or_path:
             linear_dim = 96
         else:
             linear_dim = 128
-        vprint(f"Linear Dim set to: {linear_dim} for downcasting")
+        vprint(f"Linear Dim set to: {linear_dim} for downcasting", self.verbose)
         self.linear = nn.Linear(config.hidden_size, linear_dim, bias=False)
         self.init_weights()
 
@@ -236,7 +236,8 @@ class ColBERTRanker(BaseRanker):
         model_kwargs = kwargs.get("model_kwargs", {})
         self.model = (
             ColBERTModel.from_pretrained(
-                model_name,
+                model_name, 
+                verbose=self.verbose, 
                 **model_kwargs
             )
             .to(self.device)


### PR DESCRIPTION
## Issue
The `vprint` call in `ColBERTModel.__init__` was missing its required `verbose` argument, which causes a TypeError. The function requires two arguments:
- The message to print
- The verbose level

### Reproduction
The error can be reproduced with this simple code:
```python
from rerankers import Reranker

reranker = Reranker(
    model_name="answerdotai/answerai-colbert-small-v1",
    model_type="colbert",
)

# >>> TypeError: vprint() missing 1 required positional argument: 'verbose'
```

### Breaking change
Looks like the bug was introduced in [Commit 20be7bb
](https://github.com/AnswerDotAI/rerankers/commit/20be7bbc4d5143b76301e7042302047ebfa7e4d4)

## Changes
- Added the missing `verbose` parameter to the `vprint` call in `ColBERTModel.__init__`
- Made `verbose` a required parameter in `ColBERTModel.__init__` to ensure proper initialization

## Testing
The fix ensures that logging behavior works as expected when initializing ColBERTModel instances. The model should now correctly respect the verbose level setting.

cc @ @bclavie  thanks a lot for all the great work 🙌
