### PR TITLE
Feat: added support for the Isaacus reranking API

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ pip install "rerankers[transformers]"
 # RankGPT
 pip install "rerankers[gpt]"
 
-# API-based rerankers (Cohere, Jina, MixedBread, Pinecone)
+# API-based rerankers (Cohere, Jina, MixedBread, Pinecone, Isaacus)
 pip install "rerankers[api]"
 
 # FlashRank rerankers (ONNX-optimised, very fast on CPU)
@@ -112,6 +112,9 @@ ranker = Reranker("pinecone", api_key = API_KEY)
 
 # API (Jina)
 ranker = Reranker("jina", api_key = API_KEY)
+
+# API (Isaacus)
+ranker = Reranker("isaacus", api_key = API_KEY)
 
 # RankGPT4-turbo
 ranker = Reranker("rankgpt", api_key = API_KEY)
@@ -209,7 +212,7 @@ Models:
 - ✅ RankGPT (Available both via the original RankGPT implementation and the improved RankLLM one)
 - ✅ T5-based pointwise rankers (InRanker, MonoT5...)
 - ✅ LLM-based pointwise rankers (BAAI/bge-reranker-v2.5-gemma2-lightweight, etc...)
-- ✅ Cohere, Jina, Voyage,  MixedBread, and Pinecone API rerankers
+- ✅ Cohere, Jina, Voyage,  MixedBread, Pinecone and Isaacus API rerankers
 - ✅ [FlashRank](https://github.com/PrithivirajDamodaran/FlashRank) rerankers (ONNX-optimised models, very fast on CPU)
 - ✅ ColBERT-based reranker - not a model initially designed for reranking, but does perform quite strongly in some cases. Implementation is lightweight, based only on transformers.
 - 🟠⭐ RankLLM/RankZephyr: supported by wrapping the [rank-llm library](https://github.com/castorini/rank_llm) library! Support for RankZephyr/RankVicuna is untested, but RankLLM + GPT models fully works!

--- a/examples/overview.ipynb
+++ b/examples/overview.ipynb
@@ -15,25 +15,14 @@
     "This is pretty much all there is to the library: a lightweight layer aiming to make it completely painless to slot in any reranker you want!\n",
     "\n",
     "\n",
-    "First, let's load the `Reranker` function, and fetch our API keys from our .env file to use the API-based rerankers (Cohere, Jina, RankGPT):"
+    "First, let's load the `Reranker` function, and fetch our API keys from our .env file to use the API-based rerankers (Cohere, Jina, RankGPT, Isaacus):"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "",
-     "evalue": "",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[1;31mRunning cells with '.venv (Python 3.11.11)' requires the ipykernel package.\n",
-      "\u001b[1;31mRun the following command to install 'ipykernel' into the Python environment. \n",
-      "\u001b[1;31mCommand: '/Users/bclavie/rerankers/.venv/bin/python -m pip install ipykernel -U --force-reinstall'"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# This is the only rerankers import you'll ever need for inference\n",
     "from rerankers import Reranker\n",
@@ -59,7 +48,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -433,7 +422,7 @@
    "source": [
     "## API-based models\n",
     "\n",
-    "There is an increasing amount of providers training powerful reranking models, and making them available via API calls. `rerankers` aims to support all the major ones, and make it as easy as possible to use them. Currently, we support [Jina.ai reranker](https://jina.ai/reranker/) and [Cohere Rerank](https://cohere.com/rerank).\n",
+    "There is an increasing amount of providers training powerful reranking models, and making them available via API calls. `rerankers` aims to support all the major ones, and make it as easy as possible to use them. Currently, we support [Jina.ai reranker](https://jina.ai/reranker/), [Cohere Rerank](https://cohere.com/rerank) and [Isaacus rerankers](https://isaacus.com/reranking/).\n",
     "\n",
     "Loading and using them is extremely easy. All you need is an API key, and you're ready to go:"
    ]
@@ -545,6 +534,40 @@
     "           docs=[\"Dune is an incredibly confusing masterpiece in worldbuilding...\",\n",
     "                 \"The silmarillion is a prequel to the Lord of The Rings...\",\n",
     "                 \"Green Lantern uses a powerful ring to rule over his planet...\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Auto-updated model_name to kanon-universal-classifier for API provider isaacus\n",
+      "Loading APIRanker model kanon-universal-classifier (this message can be suppressed by setting verbose=0)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "RankedResults(results=[Result(document=Document(text='In a negligence claim, the plaintiff must prove duty, breach, causation, and damages.', doc_id=2, metadata={}, document_type='text', image_path=None, base64=None), score=0.7679443124825029, rank=1), Result(document=Document(text='Negligence in tort law requires establishing a duty of care that the defendant owed to the plaintiff.', doc_id=3, metadata={}, document_type='text', image_path=None, base64=None), score=0.732858224691364, rank=2), Result(document=Document(text='The concept of negligence is central to tort law, with courts assessing whether a breach of duty caused harm.', doc_id=4, metadata={}, document_type='text', image_path=None, base64=None), score=0.32589958541887476, rank=3), Result(document=Document(text='Criminal cases involve a completely different standard, requiring proof beyond a reasonable doubt.', doc_id=1, metadata={}, document_type='text', image_path=None, base64=None), score=0.09339430960340468, rank=4), Result(document=Document(text='To form a contract, there must be an offer, acceptance, consideration, and mutual intent to be bound.', doc_id=0, metadata={}, document_type='text', image_path=None, base64=None), score=0.07008404688069232, rank=5)], query='What are the essential elements required to establish a negligence claim?', has_scores=True)"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Isaacus\n",
+    "ranker = Reranker(\"isaacus\", api_key = os.environ['ISAACUS_API_KEY'])\n",
+    "results = ranker.rank(\n",
+    "    query=\"What are the essential elements required to establish a negligence claim?\",\n",
+    "    docs=[\"To form a contract, there must be an offer, acceptance, consideration, and mutual intent to be bound.\", \"Criminal cases involve a completely different standard, requiring proof beyond a reasonable doubt.\", \"In a negligence claim, the plaintiff must prove duty, breach, causation, and damages.\", \"Negligence in tort law requires establishing a duty of care that the defendant owed to the plaintiff.\", \"The concept of negligence is central to tort law, with courts assessing whether a breach of duty caused harm.\"],\n",
+    ")\n",
+    "results"
    ]
   },
   {
@@ -1169,7 +1192,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "rerankers",
+   "display_name": ".venv",
    "language": "python",
    "name": "python3"
   },
@@ -1183,7 +1206,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.11"
+   "version": "3.12.5"
   }
  },
  "nbformat": 4,

--- a/rerankers/models/api_rankers.py
+++ b/rerankers/models/api_rankers.py
@@ -13,6 +13,7 @@ import json
 URLS = {
     "cohere": "https://api.cohere.ai/v1/rerank",
     "jina": "https://api.jina.ai/v1/rerank",
+    "isaacus": "https://api.isaacus.com/v1/rerankings",
     "voyage": "https://api.voyageai.com/v1/rerank",
     "mixedbread.ai": "https://api.mixedbread.ai/v1/reranking",
     "pinecone": "https://api.pinecone.io/rerank",
@@ -30,7 +31,8 @@ API_KEY_MAPPING = {
 
 DOCUMENT_KEY_MAPPING = {
     "mixedbread.ai": "input",
-    "text-embeddings-inference":"texts"
+    "text-embeddings-inference":"texts",
+    "isaacus": "texts",
 }
 RETURN_DOCUMENTS_KEY_MAPPING = {
     "mixedbread.ai":"return_input",
@@ -45,7 +47,8 @@ RESULTS_KEY_MAPPING = {
 SCORE_KEY_MAPPING = {
     "mixedbread.ai": "score",
     "pinecone": "score",
-    "text-embeddings-inference":"score"
+    "text-embeddings-inference":"score",
+    "isaacus":"score",
 }
 
 class APIRanker(BaseRanker):

--- a/rerankers/models/api_rankers.py
+++ b/rerankers/models/api_rankers.py
@@ -91,7 +91,6 @@ class APIRanker(BaseRanker):
             ranked_docs.append(
                 Result(
                     document=docs[r["index"]],
-                    text=self._get_document_text(r),
                     score=self._get_score(r),
                     rank=i + 1,
                 )

--- a/rerankers/reranker.py
+++ b/rerankers/reranker.py
@@ -6,6 +6,7 @@ from rerankers.utils import vprint
 
 DEFAULTS = {
     "jina": {"en": "jina-reranker-v1-base-en"},
+    "isaacus": {"en": "kanon-universal-classifier"},
     "pinecone": {"en": "pinecone-rerank-v0"},
     "cohere": {"en": "rerank-english-v3.0", "other": "rerank-multilingual-v3.0"},
     "voyage": {"en": "rerank-lite-1"},
@@ -62,7 +63,7 @@ DEPS_MAPPING = {
     "MxBaiV2Ranker": "transformers",
 }
 
-PROVIDERS = ["cohere", "jina", "voyage", "mixedbread.ai", "pinecone", "text-embeddings-inference"]
+PROVIDERS = ["cohere", "jina", "voyage", "mixedbread.ai", "pinecone", "isaacus", "text-embeddings-inference"]
 
 def _get_api_provider(model_name: str, model_type: Optional[str] = None) -> Optional[str]:
     # If an explicit model_type is provided and it isn't one of the known API providers,
@@ -89,6 +90,7 @@ def _get_model_type(model_name: str, explicit_model_type: Optional[str] = None) 
             "cohere": "APIRanker",
             "pinecone": "APIRanker",
             "jina": "APIRanker",
+            "isaacus": "APIRanker",
             "voyage": "APIRanker",
             "text-embeddings-inference": "APIRanker",
             "rankgpt": "RankGPTRanker",
@@ -118,6 +120,7 @@ def _get_model_type(model_name: str, explicit_model_type: Optional[str] = None) 
             "cohere": "APIRanker",
             "pinecone": "APIRanker",
             "jina": "APIRanker",
+            "isaacus": "APIRanker",
             "voyage": "APIRanker",
             "text-embeddings-inference": "APIRanker",
             "ms-marco-minilm-l-12-v2": "FlashRankRanker",


### PR DESCRIPTION
Hi @bclavie,
Thanks for creating this awesome library!

This PR adds support for the [Isaacus API](https://docs.isaacus.com/) and, in particular, the [Isaacus reranking endpoint](https://docs.isaacus.com/capabilities/reranking).

I have tested the PR myself and confirm that it works.

As a freebie, this PR also resolves #59 by removing the unexpected `text` argument being passed when initializing a `Result` object. It does not remove the `text` attribute from `Result` objects (which @bclavie expressed concern about [here](https://github.com/AnswerDotAI/rerankers/issues/59#issuecomment-2673744462_)), I believe there was some confusion over this but I can confirm the `text` attribute is still there, the issue in #59 was simply that a part of the codebase (`rerankers.py`) was not updated to match a change made to the `Result` object's `__init__()` method.

I have also added a code example to the notebook :)