### PR TITLE
Support of PyLate

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ rankllm = [
   "nmslib-metabrainz; python_version >= '3.10'",
   "rank-llm; python_version >= '3.10'"
 ]
+pylate = ["pylate"]
 dev = ["ruff", "isort", "pytest", "ipyprogress", "ipython", "ranx", "ir_datasets", "srsly"]
 
 [project.urls]

--- a/rerankers/models/__init__.py
+++ b/rerankers/models/__init__.py
@@ -76,3 +76,10 @@ try:
     AVAILABLE_RANKERS["MxBaiV2Ranker"] = MxBaiV2Ranker
 except ImportError:
     pass
+
+try:
+    from rerankers.models.pylate_ranker import PyLateRanker
+
+    AVAILABLE_RANKERS["PyLateRanker"] = PyLateRanker
+except ImportError:
+    pass

--- a/rerankers/models/pylate_ranker.py
+++ b/rerankers/models/pylate_ranker.py
@@ -17,8 +17,6 @@ class PyLateRanker(BaseRanker):
         dtype: Optional[Union[str, torch.dtype]] = None,
         device: Optional[Union[str, torch.device]] = None,
         verbose: int = 1,
-        query_token: str = "[unused0]",
-        document_token: str = "[unused1]",
         **kwargs,
     ):
         self.verbose = verbose
@@ -29,21 +27,15 @@ class PyLateRanker(BaseRanker):
             f"Loading model {model_name}, this might take a while...",
             self.verbose,
         )
-        tokenizer_kwargs = kwargs.get("tokenizer_kwargs", {})
-        self.tokenizer = AutoTokenizer.from_pretrained(model_name, **tokenizer_kwargs)
+        kwargs = kwargs.get("kwargs", {})
+        kwargs["device"] = self.device
         model_kwargs = kwargs.get("model_kwargs", {})
-        self.model = models.ColBERT(model_name_or_path=model_name, **model_kwargs)
-        self.model.eval()
-        # TODO: we can feed those to PyLate if needed
-        # self.query_max_length = 32  # Lower bound
-        # self.doc_max_length = (
-        #     self.model.config.max_position_embeddings - 2
-        # )  # Upper bound
-        # self.query_token_id: int = self.tokenizer.convert_tokens_to_ids(query_token)  # type: ignore
-        # self.document_token_id: int = self.tokenizer.convert_tokens_to_ids(
-        #     document_token
-        # )  # type: ignore
-        # self.normalize = True
+        model_kwargs["torch_dtype"] = self.dtype
+        self.model = models.ColBERT(
+            model_name_or_path=model_name,
+            model_kwargs=model_kwargs,
+            **kwargs,
+        )
 
     def rank(
         self,

--- a/rerankers/models/pylate_ranker.py
+++ b/rerankers/models/pylate_ranker.py
@@ -1,10 +1,6 @@
-"""Code from HotchPotch's JQaRa repository: https://github.com/hotchpotch/JQaRA/blob/main/evaluator/reranker/colbert_reranker.py
-Modifications include packaging into a BaseRanker, dynamic query/doc length and batch size handling."""
-
 from typing import List, Optional, Union
 
 import torch
-from transformers import AutoTokenizer
 
 from pylate import models, rank
 from rerankers.documents import Document

--- a/rerankers/reranker.py
+++ b/rerankers/reranker.py
@@ -45,6 +45,10 @@ DEFAULTS = {
     },
     "upr": {"en": "google/t5-large-lm-adapt"},
     "mxbaiv2": {"en": "mixedbread-ai/mxbai-rerank-base-v2"},
+    "pylate": {
+        "en": "lightonai/GTE-ModernColBERT-v1",
+        "other": "lightonai/GTE-ModernColBERT-v1",
+    },
 }
 
 DEPS_MAPPING = {
@@ -61,6 +65,7 @@ DEPS_MAPPING = {
     "LLMRelevanceFilter": "litellm",
     "UPRRanker": "transformers",
     "MxBaiV2Ranker": "transformers",
+    "PyLateRanker": "pylate",
 }
 
 PROVIDERS = ["cohere", "jina", "voyage", "mixedbread.ai", "pinecone", "isaacus", "text-embeddings-inference"]
@@ -105,6 +110,7 @@ def _get_model_type(model_name: str, explicit_model_type: Optional[str] = None) 
             "llm-relevance-filter": "LLMRelevanceFilter",
             "upr": "UPRRanker",
             "mxbaiv2": "MxBaiV2Ranker",
+            "pylate": "PyLateRanker",
         }
         return model_mapping.get(explicit_model_type, explicit_model_type)
     else:
@@ -135,6 +141,7 @@ def _get_model_type(model_name: str, explicit_model_type: Optional[str] = None) 
             "mxbaiv2": "MxBaiV2Ranker",
             "mxbai-rerank-base-v2": "MxBaiV2Ranker",
             "mxbai-rerank-large-v2": "MxBaiV2Ranker",
+            "pylate": "PyLateRanker",
         }
         for key, value in model_mapping.items():
             if key in model_name:


### PR DESCRIPTION
Hey,
This PR adds PyLate as an option for reranker.
PyLate supports all ColBERT models, including the existing one while greatly simplifying the code.
Notably, without considering dynamic expansion and the normalization, the output of the PyLate version is equivalent to the one of ColBERT reranker for stanford models.
I don't know if it is best to deprecate ColBERT or to keep it for retro-compatibility.

There's a nitpick that I'll be solving once I do the modification in PyLate: we leverage the rank.rerank function, that is leverage bogus doc_ids. It would be better to expose a simple scoring function and we already have some, but those do not support padding and thus batching for now. I'll do a PR once this is added to PyLate.
