### PR TITLE
Updated RankLLM integration into rerankers

### DIFF
--- a/rerankers/models/rankllm_ranker.py
+++ b/rerankers/models/rankllm_ranker.py
@@ -22,9 +22,14 @@ class RankLLMRanker(BaseRanker):
         window_size: int = 20,
         context_size: int = 4096,
         prompt_mode: PromptMode = PromptMode.RANK_GPT,
+        num_few_shot_examples: int = 0,
+        few_shot_file: Optional[str] = None,
+        num_gpus: int = 1,
+        variable_passages: bool = False,
+        use_logits: bool = False,
+        use_alpha: bool = False,
         stride: int = 10,
         use_azure_openai: bool = False,
-        
     ) -> "RankLLMRanker":
         self.api_key = api_key
         self.model = model
@@ -35,6 +40,12 @@ class RankLLMRanker(BaseRanker):
         self.window_size = window_size
         self.context_size = context_size
         self.prompt_mode = prompt_mode
+        self.num_few_shot_examples = num_few_shot_examples
+        self.few_shot_file = few_shot_file
+        self.num_gpus = num_gpus
+        self.variable_passages = variable_passages
+        self.use_logits = use_logits
+        self.use_alpha = use_alpha
         self.stride = stride
         self.use_azure_openai = use_azure_openai
         
@@ -43,12 +54,19 @@ class RankLLMRanker(BaseRanker):
             "default_model_coordinator": None,
             "context_size": self.context_size,
             "prompt_mode": self.prompt_mode,
+            "num_gpus": self.num_gpus,
+            "use_logits": self.use_logits,
+            "use_alpha": self.use_alpha,
+            "num_few_shot_examples": self.num_few_shot_examples,
+            "few_shot_file": self.few_shot_file,
+            "variable_passages": self.variable_passages,
             "interactive": False,
             "window_size": self.window_size,
             "stride": self.stride,
             "use_azure_openai": self.use_azure_openai,
         }
-        self.model_coordinator = rankllm_Reranker.create_model_coordinator(**kwargs)
+        model_coordinator = rankllm_Reranker.create_model_coordinator(**kwargs)
+        self.reranker = rankllm_Reranker(model_coordinator)
 
     def rank(
         self,
@@ -61,7 +79,6 @@ class RankLLMRanker(BaseRanker):
     ) -> RankedResults:
         docs = prep_docs(docs, doc_ids, metadata)
 
-        reranker = rankllm_Reranker(self.model_coordinator)
         request = Request(
             query=Query(text=query, qid=1),
             candidates=[
@@ -70,7 +87,7 @@ class RankLLMRanker(BaseRanker):
             ],
         )
 
-        rankllm_results = reranker.rerank(
+        rankllm_results = self.reranker.rerank(
             request,
             rank_end=len(docs) if rank_end == 0 else rank_end,
             window_size=min(20, len(docs)),

--- a/rerankers/models/rankllm_ranker.py
+++ b/rerankers/models/rankllm_ranker.py
@@ -48,7 +48,7 @@ class RankLLMRanker(BaseRanker):
             "stride": self.stride,
             "use_azure_openai": self.use_azure_openai,
         }
-        self.rankllm_ranker = rankllm_Reranker.create_model_coordinator(**kwargs)
+        self.model_coordinator = rankllm_Reranker.create_model_coordinator(**kwargs)
 
     def rank(
         self,
@@ -61,8 +61,7 @@ class RankLLMRanker(BaseRanker):
     ) -> RankedResults:
         docs = prep_docs(docs, doc_ids, metadata)
 
-        reranker = rankllm_Reranker(self.rankllm_ranker
-        )
+        reranker = rankllm_Reranker(self.model_coordinator)
         request = Request(
             query=Query(text=query, qid=1),
             candidates=[

--- a/rerankers/models/rankllm_ranker.py
+++ b/rerankers/models/rankllm_ranker.py
@@ -4,11 +4,11 @@ from rerankers.documents import Document
 from rerankers.results import RankedResults, Result
 from rerankers.utils import prep_docs
 
-from rank_llm.data import Candidate, Query, Request
-from rank_llm.rerank.listwise.vicuna_reranker import VicunaReranker
-from rank_llm.rerank.listwise.zephyr_reranker import ZephyrReranker
-from rank_llm.rerank.listwise.rank_gpt import SafeOpenai
+# from rerankers import Reranker
+
 from rank_llm.rerank.reranker import Reranker as rankllm_Reranker
+from rank_llm.rerank import PromptMode, get_azure_openai_args, get_genai_api_key, get_openai_api_key
+from rank_llm.data import Candidate, Query, Request
 
 
 class RankLLMRanker(BaseRanker):
@@ -18,20 +18,37 @@ class RankLLMRanker(BaseRanker):
         api_key: Optional[str] = None,
         lang: str = "en",
         verbose: int = 1,
+        # RankLLM specific arguments
+        window_size: int = 20,
+        context_size: int = 4096,
+        prompt_mode: PromptMode = PromptMode.RANK_GPT,
+        stride: int = 10,
+        use_azure_openai: bool = False,
+        
     ) -> "RankLLMRanker":
         self.api_key = api_key
         self.model = model
         self.verbose = verbose
         self.lang = lang
-
-        if "zephyr" in self.model.lower():
-            self.rankllm_ranker = ZephyrReranker()
-        elif "vicuna" in self.model.lower():
-            self.rankllm_ranker = VicunaReranker()
-        elif "gpt" in self.model.lower():
-            self.rankllm_ranker = rankllm_Reranker(
-                SafeOpenai(model=self.model, context_size=4096, keys=self.api_key)
-            )
+        
+        # RankLLM-specific parameters
+        self.window_size = window_size
+        self.context_size = context_size
+        self.prompt_mode = prompt_mode
+        self.stride = stride
+        self.use_azure_openai = use_azure_openai
+        
+        kwargs = {
+            "model_path": self.model,
+            "default_model_coordinator": None,
+            "context_size": self.context_size,
+            "prompt_mode": self.prompt_mode,
+            "interactive": False,
+            "window_size": self.window_size,
+            "stride": self.stride,
+            "use_azure_openai": self.use_azure_openai,
+        }
+        self.rankllm_ranker = rankllm_Reranker.create_model_coordinator(**kwargs)
 
     def rank(
         self,
@@ -44,6 +61,8 @@ class RankLLMRanker(BaseRanker):
     ) -> RankedResults:
         docs = prep_docs(docs, doc_ids, metadata)
 
+        reranker = rankllm_Reranker(self.rankllm_ranker
+        )
         request = Request(
             query=Query(text=query, qid=1),
             candidates=[
@@ -52,7 +71,7 @@ class RankLLMRanker(BaseRanker):
             ],
         )
 
-        rankllm_results = self.rankllm_ranker.rerank(
+        rankllm_results = reranker.rerank(
             request,
             rank_end=len(docs) if rank_end == 0 else rank_end,
             window_size=min(20, len(docs)),

--- a/rerankers/models/rankllm_ranker.py
+++ b/rerankers/models/rankllm_ranker.py
@@ -14,7 +14,7 @@ from rank_llm.data import Candidate, Query, Request
 class RankLLMRanker(BaseRanker):
     def __init__(
         self,
-        model: str,
+        model: str = "rank_zephyr",
         api_key: Optional[str] = None,
         lang: str = "en",
         verbose: int = 1,

--- a/rerankers/reranker.py
+++ b/rerankers/reranker.py
@@ -22,7 +22,7 @@ DEFAULTS = {
     "rankgpt": {"en": "gpt-4-turbo-preview", "other": "gpt-4-turbo-preview"},
     "rankgpt3": {"en": "gpt-3.5-turbo", "other": "gpt-3.5-turbo"},
     "rankgpt4": {"en": "gpt-4", "other": "gpt-4"},
-    "rankllm": {"en": "gpt-4o", "other": "gpt-4o"},
+    "rankllm": {"en": "rank_zephyr", "other": "rank_zephyr"},
     "colbert": {
         "en": "colbert-ir/colbertv2.0",
         "fr": "bclavie/FraColBERTv2",


### PR DESCRIPTION
Updated RankLLM integration with latest params, function names, etc

# Example usage with the updated integration
**Install the packages:**
```bash
pip install "rerankers[rankllm]"
```

**All the field arguments and defaults to Rreranker (with model_type="rankllm"):**
```
model: str = "rank_zephyr",
window_size: int = 20,
context_size: int = 4096,
prompt_mode: PromptMode = PromptMode.RANK_GPT,
num_few_shot_examples: int = 0,
few_shot_file: Optional[str] = None,
num_gpus: int = 1,
variable_passages: bool = False,
use_logits: bool = False,
use_alpha: bool = False,
stride: int = 10,
use_azure_openai: bool = False,
```

**Usage:**
```python
from rerankers import Reranker

ranker = Reranker('rank_zephyr', model_type="rankllm")

results = ranker.rank(query="I love you", docs=["I hate you", "I really like you"], doc_ids=[0,1])
print(results)
```