### PR TITLE
Fix typo in metadata check in utils.py

### DIFF
--- a/rerankers/utils.py
+++ b/rerankers/utils.py
@@ -95,7 +95,7 @@ def prep_docs(
                 doc_ids = list(range(len(docs)))
 
         if metadata is not None:
-            if docs[0].meatadata is not None:
+            if docs[0].metadata is not None:
                 print(
                     "Overriding doc_ids passed within the Document objects with explicitly passed doc_ids!"
                 )


### PR DESCRIPTION
This pull request fixes a typo in the `prep_docs` function in `rerankers/utils.py`. The change corrects the attribute name from `meatadata` to `metadata`, ensuring that document metadata is checked and handled properly.